### PR TITLE
Althea mobile layout

### DIFF
--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -852,6 +852,7 @@ $base: 0.6rem; //for chevron scroll animation
 .grid-container{
   display: grid;
   grid-template-columns: 1fr;
+  grid-template-rows: 0.5fr;
   grid-template-areas:
     "textbox"
     "chart";
@@ -859,9 +860,9 @@ $base: 0.6rem; //for chevron scroll animation
   align-content: start;
   width:100%;
   height: 80vh;
-  position: fixed;
+  position: sticky;
   left: 10px;
-  top: 250px;
+  top: 35vh;
   @media (min-width: 900px){
     grid-template-columns: 1fr 3fr;
     grid-template-areas:
@@ -870,7 +871,6 @@ $base: 0.6rem; //for chevron scroll animation
 }
 
 #hydro-chart-container{
-  padding: 5rem 1rem;
   font-size: 1.2rem;
   grid-area: chart; // names the grid child component
   place-self: center;

--- a/src/components/DroughtThresholds.vue
+++ b/src/components/DroughtThresholds.vue
@@ -888,7 +888,7 @@ $base: 0.6rem; //for chevron scroll animation
 .text-container {
   border-radius: 25px;
   background: #FFE3AD;
-  position:fixed;
+  position:absolute;
   p{
     padding: 15px;
   }


### PR DESCRIPTION
This drops the padding on the hydro-chart-container so that the svg falls at the top of the grid

It also switches the grid to position: sticky and the text container to position: absolute to improve the positioning of the grid on different screen sizes

It also adds a 2nd row to the grid in the mobile layout, so that the text and svg can be in separate rows